### PR TITLE
Include script path in sys path

### DIFF
--- a/gpe_utils/stoppablerunner.py
+++ b/gpe_utils/stoppablerunner.py
@@ -33,6 +33,7 @@ _prt = _ThreadPrinter()
 class StoppableRunner(bdb.Bdb):
     def __init__(self,name,captureFile=None):
         bdb.Bdb.__init__(self)
+        sys.path.append(os.path.dirname(name))
         self._stop=False
         self.captureFile=captureFile
         self.captureID=None


### PR DESCRIPTION
Allows for importing local scripts from the user's project directory

Steps to reproduce bug:

script1.py
------------
```
from script2 import hello_world
hello_world()
```
script2.py
------------
```
def hello_world():
    print "Hello World"
```
This will throw :
> ImportError: No module named script2

before this patch, and work fine after patch is applied.

I don't have an SSH setup to test this on, it may or may not fix the issue
for remote code deployment (Probably not as we'd need to beam multiple
files over)